### PR TITLE
Added 'npm test' script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "engines": [ "node" ],
   "main": "lib/smbhash.js",
   "description": "Samba LM/NT Hash Library",
-  "homepage": "https://github.com/jclulow/node-smbhash"
+  "homepage": "https://github.com/jclulow/node-smbhash",
+  "scripts": {
+    "test": "nodeunit tests/"
+  }
 }


### PR DESCRIPTION
There's a convention in the Node community of using `npm test` to test packages. That way, developers can easily test several packages without worrying about which particular test framework is used (e.g. nodeunit vs mocha vs qunit). I added a `test` script in `package.json` to enable the `npm test` command. I'm happy to report that all tests pass in Windows!

```
$ npm test

> smbhash@0.0.1 test c:\Documents and Settings\apenneba\Desktop\src\node-smbhash
> nodeunit tests/


common
✔ oddpar_success

ntlm
✔ type1_success
✔ type2_success
✔ type3_success

smbhash
✔ nthash_success
✔ lmhash_success

OK: 21 assertions (30ms)
```
