### PR TITLE
Fixed call of crypto.Cipheriv to take buffer instead of string

### DIFF
--- a/lib/smbhash.js
+++ b/lib/smbhash.js
@@ -43,8 +43,7 @@ function lmhashbuf(inputstr)
   var buf = new Buffer(16);
   var pos = 0;
   var cts = halves.forEach(function(z) {
-    var key = z.toString('binary');
-    var des = crypto.createCipheriv('DES-ECB', key, '');
+    var des = crypto.createCipheriv('DES-ECB', z, '');
     var str = des.update('KGS!@#$%', 'binary', 'binary');
     buf.write(str, pos, pos + 8, 'binary');
     pos += 8;


### PR DESCRIPTION
The `key` arg in crypto.createCipheriv() takes a buffer so no need here to convert to string
https://nodejs.org/api/crypto.html#crypto_crypto_createcipheriv_algorithm_key_iv

The main reason for me to do this was because of errors:

```
crypto.js:190
  this._handle.initiv(cipher, toBuf(key), toBuf(iv));
               ^

Error: Invalid key length
    at Error (native)
    at new Cipheriv (crypto.js:190:16)
    at Object.Cipheriv (crypto.js:188:12)
    at Object.lmhash (/Users/fmalcher/github/cis/node_modules/smbhash/lib/smbhash.js:88:20)
```